### PR TITLE
Swap Cancel and Save Buttons in "Add Mastodon Account" on iOS

### DIFF
--- a/Leviathan-iOS/Base.lproj/Main.storyboard
+++ b/Leviathan-iOS/Base.lproj/Main.storyboard
@@ -199,14 +199,14 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Add Mastodon Account" id="UeF-ey-65w">
-                        <barButtonItem key="leftBarButtonItem" systemItem="save" id="da4-pp-ynm">
-                            <connections>
-                                <action selector="saveWithSender:" destination="fnf-eF-bNw" id="5ZP-8n-BbF"/>
-                            </connections>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="cancel" id="dxo-dj-s5I">
+                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="dxo-dj-s5I">
                             <connections>
                                 <action selector="cancelWithSender:" destination="fnf-eF-bNw" id="rE4-wR-uBo"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" systemItem="save" id="da4-pp-ynm">
+                            <connections>
+                                <action selector="saveWithSender:" destination="fnf-eF-bNw" id="5ZP-8n-BbF"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>


### PR DESCRIPTION
I've swapped those buttons as usually **Save** is on the right and **Cancel** on the left side of the navigation bar, it just happened to me that I, after entering my credentials, accidentally cancelled 😆.
<img width="480" alt="screenshot 2017-04-22 08 02 58" src="https://cloud.githubusercontent.com/assets/126418/25297631/71be72f2-2732-11e7-94f3-ad5f3c927dd1.png">
 